### PR TITLE
Add next bookings endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ curl -X POST 'http://localhost:8080/api/book/batch' \
 Batch bookings run in parallel, up to 3 at a time.
 
 Use the exact WeWork name when possible. Partial names are accepted only when they match a single location.
+
+### Next bookings
+
+List your upcoming bookings:
+
+```bash
+curl 'http://localhost:8080/api/bookings/next'
+```
+
+Optionally pass `startDate` and `endDate` as `YYYY-MM-DD`:
+
+```bash
+curl 'http://localhost:8080/api/bookings/next?startDate=2026-03-01&endDate=2026-03-31'
+```

--- a/api.go
+++ b/api.go
@@ -144,6 +144,75 @@ func registerBatchBookHandler(auth *WeWorkAuthenticator, cacheManager *cache.Cac
 	}
 }
 
+func registerNextBookingsHandler(auth *WeWorkAuthenticator) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		startDate, endDate, err := normalizeNextBookingsDateRange(r.URL.Query().Get("startDate"), r.URL.Query().Get("endDate"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		taskCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+
+		bearerToken, err := auth.BearerToken(taskCtx)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		bookings, err := FetchNextBookings(taskCtx, bearerToken, startDate, endDate)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write(bookings)
+	}
+}
+
+func normalizeNextBookingsDateRange(startDate string, endDate string) (string, string, error) {
+	start, err := normalizeNextBookingsDate(startDate, "startDate")
+	if err != nil {
+		return "", "", err
+	}
+
+	end, err := normalizeNextBookingsDate(endDate, "endDate")
+	if err != nil {
+		return "", "", err
+	}
+
+	if start != "" && end != "" {
+		parsedStart, _ := time.Parse(time.DateOnly, start)
+		parsedEnd, _ := time.Parse(time.DateOnly, end)
+		if parsedEnd.Before(parsedStart) {
+			return "", "", errors.New("endDate must be on or after startDate")
+		}
+	}
+
+	return start, end, nil
+}
+
+func normalizeNextBookingsDate(date string, field string) (string, error) {
+	if date == "" {
+		return "", nil
+	}
+
+	parsed, err := time.Parse(time.DateOnly, date)
+	if err != nil {
+		return "", fmt.Errorf("invalid %s format. Expected format: 'YYYY-MM-DD'", field)
+	}
+
+	return parsed.Format(time.DateOnly), nil
+}
+
 func newBatchBookResponse(wework string, results []batchBookResult) batchBookResponse {
 	response := batchBookResponse{Wework: wework, Results: results}
 	for _, result := range results {

--- a/api_test.go
+++ b/api_test.go
@@ -81,6 +81,40 @@ func TestNewBatchBookResponseIncludesCountsAndSummary(t *testing.T) {
 	}
 }
 
+func TestNormalizeNextBookingsDateRangeAllowsEmptyDates(t *testing.T) {
+	startDate, endDate, err := normalizeNextBookingsDateRange("", "")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if startDate != "" || endDate != "" {
+		t.Fatalf("Expected empty dates, got %q and %q", startDate, endDate)
+	}
+}
+
+func TestNormalizeNextBookingsDateRangeAcceptsDateOnly(t *testing.T) {
+	startDate, endDate, err := normalizeNextBookingsDateRange("2026-03-01", "2026-03-31")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if startDate != "2026-03-01" || endDate != "2026-03-31" {
+		t.Fatalf("Unexpected dates: %q and %q", startDate, endDate)
+	}
+}
+
+func TestNormalizeNextBookingsDateRangeRejectsInvalidDate(t *testing.T) {
+	if _, _, err := normalizeNextBookingsDateRange("Mar 1, 2026", ""); err == nil {
+		t.Fatalf("Expected error for invalid date")
+	}
+}
+
+func TestNormalizeNextBookingsDateRangeRejectsEndBeforeStart(t *testing.T) {
+	if _, _, err := normalizeNextBookingsDateRange("2026-03-31", "2026-03-01"); err == nil {
+		t.Fatalf("Expected error for endDate before startDate")
+	}
+}
+
 func TestNewBatchBookResponseSummarizesFullSuccess(t *testing.T) {
 	response := newBatchBookResponse("Coeur Marais", []batchBookResult{
 		{Date: "Mar 1, 2026", Status: "success"},

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	// also set up a custom logger
 	http.HandleFunc("/api/book", registerBookHandler(auth, cacheManager))
 	http.HandleFunc("/api/book/batch", registerBatchBookHandler(auth, cacheManager))
+	http.HandleFunc("/api/bookings/next", registerNextBookingsHandler(auth))
 	log.Println("Starting server on port 8080...")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 

--- a/weworkrequests.go
+++ b/weworkrequests.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -338,6 +342,43 @@ type BookingResponse struct {
 	Errors        []string `json:"Errors"`
 	ReservationID string   `json:"ReservationID"`
 	WeworkUUID    string   `json:"WeWorkUUID"`
+}
+
+func FetchNextBookings(ctx context.Context, token string, startDate string, endDate string) (json.RawMessage, error) {
+	values := url.Values{}
+	values.Set("isPastBooking", "false")
+	values.Set("platFormType", "WEB")
+	values.Set("startDate", startDate)
+	values.Set("endDate", endDate)
+
+	requestURL := "https://members.wework.com/workplaceone/api/common-booking/get-app-upcoming-bookings?" + values.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("error fetching bookings: %s", resp.Status)
+	}
+
+	if !json.Valid(body) {
+		return nil, errors.New("bookings response was not valid JSON")
+	}
+
+	return json.RawMessage(body), nil
 }
 
 var makeBookingRequestFunc = makeBookingRequest


### PR DESCRIPTION
## Summary
- add GET /api/bookings/next for upcoming WeWork bookings
- support optional startDate and endDate query params in YYYY-MM-DD format
- document endpoint usage and add date validation tests

## Testing
- go test "api.go" "browser.go" "weworkrequests.go" "api_test.go" "weworkrequests_test.go" "dateformat.go" "auth.go"

Note: full go test ./... is blocked by pre-existing missing go.sum entries for untracked tracing.go OpenTelemetry imports.