### PR TITLE
Add cancel booking endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ Optionally pass `startDate` and `endDate` as `YYYY-MM-DD`:
 ```bash
 curl 'http://localhost:8080/api/bookings/next?startDate=2026-03-01&endDate=2026-03-31'
 ```
+
+### Cancel booking
+
+Cancel a single booking:
+
+```bash
+curl -X POST 'http://localhost:8080/api/bookings/cancel' \
+  -H 'Content-Type: application/json' \
+  -d '{"bookingId":"..."}'
+```

--- a/api.go
+++ b/api.go
@@ -263,13 +263,13 @@ func registerCancelBookingHandler(auth *WeWorkAuthenticator) func(w http.Respons
 			return
 		}
 
-		bookings, err := FetchNextBookings(taskCtx, bearerToken, "", "")
+		bookingDetails, err := FetchBookingDetails(taskCtx, bearerToken, payload.BookingID)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		booking, err := findCancelBookingItem(bookings, payload.BookingID)
+		booking, err := findCancelBookingItem(bookingDetails, payload.BookingID)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -281,31 +281,57 @@ func registerCancelBookingHandler(auth *WeWorkAuthenticator) func(w http.Respons
 			return
 		}
 
-		response, err := CancelWeWorkBooking(taskCtx, bearerToken, cancelRequest)
-		if err != nil {
+		if err := CancelWeWorkBooking(taskCtx, bearerToken, cancelRequest); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
+		response := map[string]string{"message": "ok"}
+
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		w.Write(response)
+		json.NewEncoder(w).Encode(response)
 	}
 }
 
 func findCancelBookingItem(bookings json.RawMessage, bookingID string) (cancelBookingItem, error) {
-	var items []cancelBookingItem
-	if err := json.Unmarshal(bookings, &items); err != nil {
+	var payload any
+	if err := json.Unmarshal(bookings, &payload); err != nil {
 		return cancelBookingItem{}, errors.New("unexpected bookings response format")
 	}
 
-	for _, item := range items {
-		if item.BookingID == bookingID || item.KubeBookingExternalReference == bookingID {
-			return item, nil
+	if item, ok := findCancelBookingItemValue(payload, bookingID); ok {
+		return item, nil
+	}
+
+	return cancelBookingItem{}, fmt.Errorf("bookingId %q not found in booking details", bookingID)
+}
+
+func findCancelBookingItemValue(value any, bookingID string) (cancelBookingItem, bool) {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			if booking, ok := findCancelBookingItemValue(item, bookingID); ok {
+				return booking, true
+			}
+		}
+	case map[string]any:
+		encoded, err := json.Marshal(typed)
+		if err == nil {
+			var booking cancelBookingItem
+			if err := json.Unmarshal(encoded, &booking); err == nil && (booking.BookingID == bookingID || booking.KubeBookingExternalReference == bookingID) {
+				return booking, true
+			}
+		}
+
+		for _, item := range typed {
+			if booking, ok := findCancelBookingItemValue(item, bookingID); ok {
+				return booking, true
+			}
 		}
 	}
 
-	return cancelBookingItem{}, fmt.Errorf("bookingId %q not found in upcoming bookings", bookingID)
+	return cancelBookingItem{}, false
 }
 
 func newWeWorkCancelBookingRequest(booking cancelBookingItem) (weWorkCancelBookingRequest, error) {

--- a/api.go
+++ b/api.go
@@ -90,6 +90,62 @@ type batchBookResponse struct {
 	Results      []batchBookResult `json:"results"`
 }
 
+type cancelBookingRequest struct {
+	BookingID string `json:"bookingId"`
+}
+
+type cancelBookingItem struct {
+	BookingID                    string  `json:"bookingId"`
+	KubeBookingExternalReference string  `json:"kubeBookingExternalReference"`
+	IsFranchiseBooking           bool    `json:"isFranchiseBooking"`
+	UseKubeAPI                   bool    `json:"useKubeApi"`
+	CreditCost                   float64 `json:"creditCost"`
+	StartDate                    string  `json:"startDate"`
+	EndDate                      string  `json:"endDate"`
+	SpaceID                      string  `json:"spaceId"`
+	SpaceExternalReference       string  `json:"spaceExternalReference"`
+	SpaceType                    int     `json:"spaceType"`
+	BookingType                  int     `json:"bookingType"`
+	IsHybridSpace                bool    `json:"isHybridSpace"`
+	BookingDate                  string  `json:"bookingDate"`
+	Location                     struct {
+		ID         string `json:"id"`
+		SourceType int    `json:"sourceType"`
+		Address    struct {
+			ID      string `json:"id"`
+			Line1   string `json:"line1"`
+			Line2   string `json:"line2"`
+			Country string `json:"country"`
+		} `json:"address"`
+	} `json:"location"`
+}
+
+type weWorkCancelBookingRequest struct {
+	BookingID           string                  `json:"bookingId"`
+	BookingLocationType int                     `json:"bookingLocationType"`
+	CreditsUsed         float64                 `json:"creditsUsed"`
+	StartTime           string                  `json:"startTime"`
+	EndTime             string                  `json:"endTime"`
+	LocationID          string                  `json:"locationId"`
+	ReservableID        string                  `json:"reservableId"`
+	IsBookingApprovalOn bool                    `json:"isBookingApprovalOn"`
+	BookingType         int                     `json:"bookingType"`
+	SpaceID             string                  `json:"spaceId"`
+	CancellationNote    string                  `json:"cancellationNote"`
+	MailParams          cancelBookingMailParams `json:"mailParams"`
+	ReservationID       string                  `json:"reservationId"`
+}
+
+type cancelBookingMailParams struct {
+	WorkspaceType      int    `json:"workspaceType"`
+	DayFormatted       string `json:"dayFormatted"`
+	StartTimeFormatted string `json:"startTimeFormatted"`
+	EndTimeFormatted   string `json:"endTimeFormatted"`
+	FloorAddress       string `json:"floorAddress"`
+	LocationAddress    string `json:"locationAddress"`
+	LocationCountry    string `json:"locationCountry"`
+}
+
 func registerBatchBookHandler(auth *WeWorkAuthenticator, cacheManager *cache.Cache[[]byte]) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -176,6 +232,140 @@ func registerNextBookingsHandler(auth *WeWorkAuthenticator) func(w http.Response
 		w.WriteHeader(http.StatusOK)
 		w.Write(bookings)
 	}
+}
+
+func registerCancelBookingHandler(auth *WeWorkAuthenticator) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var payload cancelBookingRequest
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&payload); err != nil {
+			http.Error(w, "Invalid JSON body", http.StatusBadRequest)
+			return
+		}
+
+		if payload.BookingID == "" {
+			http.Error(w, "missing bookingId", http.StatusBadRequest)
+			return
+		}
+
+		taskCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+
+		bearerToken, err := auth.BearerToken(taskCtx)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		bookings, err := FetchNextBookings(taskCtx, bearerToken, "", "")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		booking, err := findCancelBookingItem(bookings, payload.BookingID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		cancelRequest, err := newWeWorkCancelBookingRequest(booking)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		response, err := CancelWeWorkBooking(taskCtx, bearerToken, cancelRequest)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write(response)
+	}
+}
+
+func findCancelBookingItem(bookings json.RawMessage, bookingID string) (cancelBookingItem, error) {
+	var items []cancelBookingItem
+	if err := json.Unmarshal(bookings, &items); err != nil {
+		return cancelBookingItem{}, errors.New("unexpected bookings response format")
+	}
+
+	for _, item := range items {
+		if item.BookingID == bookingID || item.KubeBookingExternalReference == bookingID {
+			return item, nil
+		}
+	}
+
+	return cancelBookingItem{}, fmt.Errorf("bookingId %q not found in upcoming bookings", bookingID)
+}
+
+func newWeWorkCancelBookingRequest(booking cancelBookingItem) (weWorkCancelBookingRequest, error) {
+	bookingID := booking.BookingID
+	if booking.IsFranchiseBooking && booking.KubeBookingExternalReference != "" {
+		bookingID = booking.KubeBookingExternalReference
+	}
+	if bookingID == "" {
+		return weWorkCancelBookingRequest{}, errors.New("booking is missing bookingId")
+	}
+
+	reservationID := bookingID
+	if booking.UseKubeAPI && booking.KubeBookingExternalReference != "" {
+		reservationID = booking.KubeBookingExternalReference
+	}
+
+	locationID := booking.Location.Address.ID
+	if locationID == "" {
+		locationID = booking.Location.ID
+	}
+	if locationID == "" {
+		return weWorkCancelBookingRequest{}, errors.New("booking is missing location id")
+	}
+
+	spaceID := booking.SpaceID
+	if booking.IsFranchiseBooking && booking.SpaceExternalReference != "" {
+		spaceID = booking.SpaceExternalReference
+	}
+	if spaceID == "" {
+		return weWorkCancelBookingRequest{}, errors.New("booking is missing spaceId")
+	}
+
+	bookingType := booking.BookingType
+	if bookingType == 0 {
+		bookingType = 4
+	}
+
+	return weWorkCancelBookingRequest{
+		BookingID:           bookingID,
+		BookingLocationType: booking.Location.SourceType,
+		CreditsUsed:         booking.CreditCost,
+		StartTime:           booking.StartDate,
+		EndTime:             booking.EndDate,
+		LocationID:          locationID,
+		ReservableID:        spaceID,
+		IsBookingApprovalOn: booking.IsHybridSpace,
+		BookingType:         bookingType,
+		SpaceID:             spaceID,
+		CancellationNote:    "",
+		MailParams: cancelBookingMailParams{
+			WorkspaceType:      booking.SpaceType,
+			DayFormatted:       booking.BookingDate,
+			StartTimeFormatted: booking.StartDate,
+			EndTimeFormatted:   booking.EndDate,
+			FloorAddress:       "",
+			LocationAddress:    booking.Location.Address.Line1 + " " + booking.Location.Address.Line2,
+			LocationCountry:    booking.Location.Address.Country,
+		},
+		ReservationID: reservationID,
+	}, nil
 }
 
 func normalizeNextBookingsDateRange(startDate string, endDate string) (string, string, error) {

--- a/api_test.go
+++ b/api_test.go
@@ -166,6 +166,19 @@ func TestFindCancelBookingItemFindsBookingByID(t *testing.T) {
 	}
 }
 
+func TestFindCancelBookingItemFindsWrappedBookingDetails(t *testing.T) {
+	bookings := json.RawMessage(`{"booking":{"bookingId":"booking-123","spaceId":"space-123","location":{"id":"location-123"}}}`)
+
+	booking, err := findCancelBookingItem(bookings, "booking-123")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if booking.BookingID != "booking-123" {
+		t.Fatalf("Unexpected booking id: %s", booking.BookingID)
+	}
+}
+
 func TestFindCancelBookingItemRejectsMissingBooking(t *testing.T) {
 	bookings := json.RawMessage(`[{"bookingId":"booking-123"}]`)
 

--- a/api_test.go
+++ b/api_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -113,6 +114,94 @@ func TestNormalizeNextBookingsDateRangeRejectsEndBeforeStart(t *testing.T) {
 	if _, _, err := normalizeNextBookingsDateRange("2026-03-31", "2026-03-01"); err == nil {
 		t.Fatalf("Expected error for endDate before startDate")
 	}
+}
+
+func TestNewWeWorkCancelBookingRequestBuildsSingleCancelPayload(t *testing.T) {
+	booking := newTestCancelBookingItem("booking-123", "location-123", "space-123")
+	booking.CreditCost = 2
+	booking.StartDate = "2026-03-01T06:00:00Z"
+	booking.EndDate = "2026-03-01T23:59:00Z"
+	booking.SpaceType = 1
+	booking.BookingDate = "2026-03-01"
+	booking.Location.SourceType = 2
+	booking.Location.Address.Line1 = "115 Broadway"
+	booking.Location.Address.Line2 = "Floor 4"
+	booking.Location.Address.Country = "US"
+
+	cancelRequest, err := newWeWorkCancelBookingRequest(booking)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if cancelRequest.BookingID != "booking-123" {
+		t.Fatalf("Unexpected booking id: %s", cancelRequest.BookingID)
+	}
+	if cancelRequest.BookingType != 4 {
+		t.Fatalf("Expected default shared workspace booking type, got %d", cancelRequest.BookingType)
+	}
+	if cancelRequest.SpaceID != "space-123" || cancelRequest.ReservableID != "space-123" {
+		t.Fatalf("Unexpected space fields: %+v", cancelRequest)
+	}
+	if cancelRequest.CreditsUsed != 2 {
+		t.Fatalf("Unexpected credits used: %f", cancelRequest.CreditsUsed)
+	}
+	if cancelRequest.ReservationID != "booking-123" {
+		t.Fatalf("Unexpected reservation id: %s", cancelRequest.ReservationID)
+	}
+	if cancelRequest.MailParams.LocationAddress != "115 Broadway Floor 4" {
+		t.Fatalf("Unexpected mail location: %s", cancelRequest.MailParams.LocationAddress)
+	}
+}
+
+func TestFindCancelBookingItemFindsBookingByID(t *testing.T) {
+	bookings := json.RawMessage(`[{"bookingId":"booking-123","spaceId":"space-123","location":{"id":"location-123"}}]`)
+
+	booking, err := findCancelBookingItem(bookings, "booking-123")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if booking.BookingID != "booking-123" {
+		t.Fatalf("Unexpected booking id: %s", booking.BookingID)
+	}
+}
+
+func TestFindCancelBookingItemRejectsMissingBooking(t *testing.T) {
+	bookings := json.RawMessage(`[{"bookingId":"booking-123"}]`)
+
+	if _, err := findCancelBookingItem(bookings, "missing"); err == nil {
+		t.Fatalf("Expected error for missing booking")
+	}
+}
+
+func TestNewWeWorkCancelBookingRequestRejectsMissingBookingID(t *testing.T) {
+	booking := newTestCancelBookingItem("", "location-123", "space-123")
+
+	if _, err := newWeWorkCancelBookingRequest(booking); err == nil {
+		t.Fatalf("Expected error for missing booking id")
+	}
+}
+
+func TestNewWeWorkCancelBookingRequestRejectsMissingLocationID(t *testing.T) {
+	booking := newTestCancelBookingItem("booking-123", "", "space-123")
+
+	if _, err := newWeWorkCancelBookingRequest(booking); err == nil {
+		t.Fatalf("Expected error for missing location id")
+	}
+}
+
+func TestNewWeWorkCancelBookingRequestRejectsMissingSpaceID(t *testing.T) {
+	booking := newTestCancelBookingItem("booking-123", "location-123", "")
+
+	if _, err := newWeWorkCancelBookingRequest(booking); err == nil {
+		t.Fatalf("Expected error for missing space id")
+	}
+}
+
+func newTestCancelBookingItem(bookingID string, locationID string, spaceID string) cancelBookingItem {
+	booking := cancelBookingItem{BookingID: bookingID, SpaceID: spaceID}
+	booking.Location.ID = locationID
+	return booking
 }
 
 func TestNewBatchBookResponseSummarizesFullSuccess(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 	http.HandleFunc("/api/book", registerBookHandler(auth, cacheManager))
 	http.HandleFunc("/api/book/batch", registerBatchBookHandler(auth, cacheManager))
 	http.HandleFunc("/api/bookings/next", registerNextBookingsHandler(auth))
+	http.HandleFunc("/api/bookings/cancel", registerCancelBookingHandler(auth))
 	log.Println("Starting server on port 8080...")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 

--- a/weworkrequests.go
+++ b/weworkrequests.go
@@ -381,24 +381,21 @@ func FetchNextBookings(ctx context.Context, token string, startDate string, endD
 	return json.RawMessage(body), nil
 }
 
-func CancelWeWorkBooking(ctx context.Context, token string, cancelRequest weWorkCancelBookingRequest) (json.RawMessage, error) {
+func FetchBookingDetails(ctx context.Context, token string, bookingID string) (json.RawMessage, error) {
 	values := url.Values{}
-	values.Set("isOnDemand", "false")
+	values.Set("propertyType", "2")
+	values.Set("reservationId", bookingID)
+	values.Set("bookingId", bookingID)
 	values.Set("platFormType", "WEB")
+	values.Set("sourceType", "0")
 
-	body, err := json.Marshal(cancelRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	requestURL := "https://members.wework.com/workplaceone/api/common-booking/cancel?" + values.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, strings.NewReader(string(body)))
+	requestURL := "https://members.wework.com/workplaceone/api/common-booking/get-specific-booking-data?" + values.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -406,24 +403,61 @@ func CancelWeWorkBooking(ctx context.Context, token string, cancelRequest weWork
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("error cancelling booking: %s", resp.Status)
+		return nil, fmt.Errorf("error fetching booking details: %s", resp.Status)
 	}
 
-	if len(responseBody) == 0 {
-		return json.RawMessage(`{"cancelled":true}`), nil
+	if !json.Valid(body) {
+		return nil, errors.New("booking details response was not valid JSON")
 	}
 
-	if json.Valid(responseBody) {
-		return json.RawMessage(responseBody), nil
+	return json.RawMessage(body), nil
+}
+
+func CancelWeWorkBooking(ctx context.Context, token string, cancelRequest weWorkCancelBookingRequest) error {
+	values := url.Values{}
+	values.Set("isOnDemand", "false")
+	values.Set("platFormType", "WEB")
+
+	body, err := json.Marshal(cancelRequest)
+	if err != nil {
+		return err
 	}
 
-	return json.RawMessage(fmt.Sprintf(`{"cancelled":%t,"response":%q}`, strings.EqualFold(string(responseBody), "true"), string(responseBody))), nil
+	requestURL := "https://members.wework.com/workplaceone/api/common-booking/cancel?" + values.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("error cancelling booking: %s", resp.Status)
+	}
+
+	if len(responseBody) > 0 && !json.Valid(responseBody) && !strings.EqualFold(string(responseBody), "true") {
+		return fmt.Errorf("unexpected cancel booking response: %s", string(responseBody))
+	}
+
+	return nil
 }
 
 var makeBookingRequestFunc = makeBookingRequest

--- a/weworkrequests.go
+++ b/weworkrequests.go
@@ -381,6 +381,51 @@ func FetchNextBookings(ctx context.Context, token string, startDate string, endD
 	return json.RawMessage(body), nil
 }
 
+func CancelWeWorkBooking(ctx context.Context, token string, cancelRequest weWorkCancelBookingRequest) (json.RawMessage, error) {
+	values := url.Values{}
+	values.Set("isOnDemand", "false")
+	values.Set("platFormType", "WEB")
+
+	body, err := json.Marshal(cancelRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	requestURL := "https://members.wework.com/workplaceone/api/common-booking/cancel?" + values.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, strings.NewReader(string(body)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("error cancelling booking: %s", resp.Status)
+	}
+
+	if len(responseBody) == 0 {
+		return json.RawMessage(`{"cancelled":true}`), nil
+	}
+
+	if json.Valid(responseBody) {
+		return json.RawMessage(responseBody), nil
+	}
+
+	return json.RawMessage(fmt.Sprintf(`{"cancelled":%t,"response":%q}`, strings.EqualFold(string(responseBody), "true"), string(responseBody))), nil
+}
+
 var makeBookingRequestFunc = makeBookingRequest
 
 // parseTimezoneOffset parses a timezone offset string like "GMT +02:00" or "GMT -05:00"


### PR DESCRIPTION
## Summary
- add POST /api/bookings/cancel accepting only bookingId
- fetch latest upcoming bookings before cancellation and build the WeWork cancel payload from fresh data
- document the endpoint and add tests for lookup and payload validation

## Testing
- go test ./...